### PR TITLE
Removing .vscode directory

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "git.ignoreLimitWarning": true
-}


### PR DESCRIPTION
Don't think it is good practice to store personal settings directory in the repository. If necessary to configure VSCode, it is better practice to have git not track the folder. [This](https://stackoverflow.com/questions/24290358/remove-a-folder-from-git-tracking) describes how to have the settings configuration remain on your local disc even after git sees the folder as deleted