### PR TITLE
Temporarily disable autoupdate on Linux due to unavailable latest-linux.yml

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -101,7 +101,9 @@ class App {
 				this.mainWindow.webContents.openDevTools();
 			});
 		
-			this.updater.check();
+			if(process.platform !== 'linux'){
+				this.updater.check();
+			}
 		
 			this.setActivity(this.rpcData);
 		});

--- a/src/main.js
+++ b/src/main.js
@@ -101,7 +101,7 @@ class App {
 				this.mainWindow.webContents.openDevTools();
 			});
 		
-			if(process.platform !== 'linux'){
+			if(process.platform !== 'linux'){ //TEMPORARY FIX UNTIL RELEASES YML IS AVAILABLE
 				this.updater.check();
 			}
 		

--- a/src/modules/ManualUpdater.js
+++ b/src/modules/ManualUpdater.js
@@ -56,6 +56,8 @@ autoUpdater.on('update-downloaded', () => {
 function checkForUpdates (menuItem, focusedWindow, event) { // eslint-disable-line no-unused-vars
 	updater = menuItem;
 	updater.enabled = false;
-	autoUpdater.checkForUpdates();
+	if (process.platform !== 'linux'){
+		autoUpdater.checkForUpdates();
+	}
 }
 module.exports.checkForUpdates = checkForUpdates;


### PR DESCRIPTION
Problem: Auto-update and manual update functions on Linux throw a massive error dialog box due to https://github.com/RailRunner166/MyRPC/releases/download/v1.1.0/latest-linux.yml returning not found. 

Temporary solution: Disable auto-update and manual update method calls for Linux platform.